### PR TITLE
Link directly to page 1 for guya.moe albums

### DIFF
--- a/process_comment.py
+++ b/process_comment.py
@@ -102,7 +102,7 @@ async def process_comment(comment: Comment, reddit: Reddit):
 
 			if imgur_match:
 				comment.parent().edit(
-					f"The source OP provided:  \n> <{url}>\n\nAlt link: [guya.moe](https://guya.moe/proxy/imgur/{imgur_match.group(1)})\n\n"
+					f"The source OP provided:  \n> <{url}>\n\nAlt link: [guya.moe](https://guya.moe/proxy/imgur/{imgur_match.group(1)}/1/1/)\n\n"
 					f'{config["suffix"]}'
 				)
 			else:
@@ -407,7 +407,7 @@ async def process_comment(comment: Comment, reddit: Reddit):
 
 				if imgur_match:
 					comment.parent().edit(
-						f"The source OP provided:  \n> <{url}>\n\nAlt link: [guya.moe](https://guya.moe/proxy/imgur/{imgur_match.group(1)})\n\n"
+						f"The source OP provided:  \n> <{url}>\n\nAlt link: [guya.moe](https://guya.moe/proxy/imgur/{imgur_match.group(1)}/1/1/)\n\n"
 						f'{config["suffix"]}'
 					)
 				else:


### PR DESCRIPTION
The current implementation links to the main page, but since they are automatically generated by the site, they don't have any addition info, making them useless. Linking to the first page (like we do on our site) makes more sense.