### PR TITLE
Markdown and Tags

### DIFF
--- a/process_comment.py
+++ b/process_comment.py
@@ -346,7 +346,7 @@ async def process_comment(comment: Comment, reddit: Reddit):
 					print("Illegal artists detected: " + ', '.join(detected_artists))
 
 					remove_post(reddit, comment,
-						f'The provided source has the following disallowed artists:\n```\n{", ".join(detected_artists)}\n```\n'
+						f'The provided source has the following disallowed artists:\n\n```\n{", ".join(detected_artists)}\n```\n\n'
 						'These artists are banned because their works are always or almost always licensed. '
 						f'Please [contact the mods](https://www.reddit.com/message/compose?to=/r/{config["subreddit"]}) if you think this is '
 						'an unlicensed exception. '
@@ -368,7 +368,7 @@ async def process_comment(comment: Comment, reddit: Reddit):
 					print("Illegal tags detected: " + ', '.join(detected_tags))
 
 					remove_post(reddit, comment,
-						f'The provided source has the following disallowed tags:\n```\n{", ".join(detected_tags)}\n```\n'
+						f'The provided source has the following disallowed tags:\n\n```\n{", ".join(detected_tags)}\n```\n\n'
 						'These tags are banned because they are either almost never wholesome or almost always licensed. '
 						f'Please [contact the mods](https://www.reddit.com/message/compose?to=/r/{config["subreddit"]}) if you think this is either '
 						'a mistagged doujin or a wholesome/unlicensed exception. '

--- a/process_post.py
+++ b/process_post.py
@@ -69,7 +69,7 @@ async def process_post(submission: Submission):
 
 async def ask_for_sauce(submission: Submission):
 	comment = submission.reply('**Reply to this comment** with the source. This can be either just the digits,'
-	                           'like 258133, or a URL, such as  \n```\nhttps://nhentai.net/g/(numbers).\n```\n'
+	                           ' like 258133, or a URL, such as  \n\n```\nhttps://nhentai.net/g/(numbers).\n```\n\n'
 	                           'You may also reply with a link to most non-nhentai URLs. We prefer you use nhentai in'
 	                           ' most cases, but in certain cases, imgur is acceptable.'
 	                           '\n\n' + config['suffix'])

--- a/removals.json
+++ b/removals.json
@@ -24,7 +24,13 @@
 		"cannibalism",
 		"urethra insertion",
 		"webtoon",
-		"forbidden content"
+		"forbidden content",
+		"skinsuit",
+		"oppai loli",
+		"age regression",
+		"chloroform",
+		"mind control",
+		"unbirth"
 	],
 	"licensedSites": [
 		"hentai.cafe",


### PR DESCRIPTION
This PR has 3 changes:

* Adds some unwholesome tags to the blacklist

* Adds a missing space

* Fixes the code blocks formatting on old reddit

Regarding the last point, this change was only applied to 3 comments, since the other ones (for licensed issues, underage characters, etc.) either use a different formatting or don't have code blocks, so it wasn't necessary.