### PR TITLE
Fix token search for Imgchest

### DIFF
--- a/process_comment.py
+++ b/process_comment.py
@@ -647,8 +647,7 @@ async def format_body(url: str, data: tuple | None = None) -> str:
 				f'{config["suffix"]}')
 
 	else:
-		imgchest = re.compile(r"https://www\.imgchest\.com/p/([0-9a-zA-Z]{11})/")
-		imgchest_match = imgchest.match(url)
+		imgchest_match = re.search(r'([0-9a-zA-Z]{11})', url)
 
 		if imgchest_match:
 			try:


### PR DESCRIPTION
Imgchest links _might_ include the www subdomain, but if they don't, the bot would crash (since the regex returns None). We can simplify the search to avoid this