### PR TITLE
Improve hentai_fetcher logic, use nhentai API, other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ posts.db
 .idea/
 __pycache__/
 nohup.out
+.venv
+.vscode

--- a/clean_up_posts.py
+++ b/clean_up_posts.py
@@ -1,8 +1,8 @@
+import json
 import praw
 import sqlite3
-from sqlite3 import Error, Connection
-import json
 import time
+from sqlite3 import Connection, Error
 
 
 def create_connection(path: str) -> Connection:
@@ -31,6 +31,7 @@ reddit = praw.Reddit(client_id=config['id'],
 
 c.execute("SELECT * FROM posts")
 records = c.fetchall()
+
 for row in records:
 	print(f"Checking post: {row[0]}")
 	submission = reddit.submission(url=f'https://reddit.com{row[0]}')
@@ -40,8 +41,10 @@ for row in records:
 	if submission.removed:
 		print("This submission was removed.")
 		c.execute('UPDATE posts SET removed=1 WHERE source=?', (row[1],))
+
 c.execute('DELETE FROM posts WHERE timeposted<?', (int(time.time()) - (8 * 604800),))
 c.execute("DELETE FROM posts WHERE source LIKE '%hc.fyi%'")
 c.execute("DELETE FROM posts WHERE source LIKE '%hentainexus%'")
 c.execute("DELETE FROM posts WHERE source LIKE '%hentai.cafe%'")
+
 conn.commit()

--- a/hentai_fetcher.py
+++ b/hentai_fetcher.py
@@ -3,14 +3,50 @@ import re
 import traceback
 
 import aiohttp
-from bs4 import BeautifulSoup
 import asyncio
-from functional import seq
+from bs4 import BeautifulSoup
+
+
+LICENSED_MAGAZINES = {
+	"always_licensed": [
+		"happining",
+		"aoha",
+		"weekly kairakuten",
+		"dascomi",
+	],
+	"partially_licensed": {
+		"kairakuten": ["2015-06", "9999-99", None, None],
+		"x-eros": [None, None, 30, -1],
+		"shitsurakuten": ["2016-04", "9999-99", None, None],
+		"kairakuten beast": ["2016-12", "9999-99", None, None],
+		"bavel": ["2017-06", "9999-99", None, None],
+		"europa": ["2017-04", "9999-99", 11, -1],
+		"girls form": [None, None, 13, 16],
+		"koh": ["2013-12", "2014-07", 1, 2]
+	}
+}
+
+# nhentai regexes
+NUMBERS_REGEX = re.compile(r"/g/(\d{1,6})/?")
+
+# magazine date regexes
+DATE_PATTERN = re.compile(r"(\d+)-(\d+)")
+DATE_PATTERN_2 = re.compile(r"\D*(\d+)\D*")
+
+# Generic regexes
+TITLE_EXTRACTOR = re.compile(
+	r"^(?:\s*(?:=.*?=|<.*?>|\[.*?]|\(.*?\)|{.*?})\s*)*(?:[^\[|\](){}<>=]*\s*\|\s*)?([^\[|\](){}<>=]*?)(?:\s*(?:=.*?=|<.*?>|\[.*?]|\(.*?\)|{.*?})\s*)*$")
+
+# special magazine regexes
+# See if this doujin has a magazine associated with it
+MAGAZINE_REGEX = re.compile(r".*\(\s*comic\s*(.+?)\s*(?:vol\.)?\s*((\d|-|#|,|\s)*)\)")
+# (girls forM is annoying because it doesn't have a COMIC, so I have to use another regex)
+GIRLS_FORM_REGEX = re.compile(r".*\(\s*girls\s*form\s*(?:vol\.)?\s*(.+?)\)")
+# (so is Weekly Kairakuten)
+WEEKLY_MAG_REGEX = re.compile(r".*\(\s*weekly\s*kairakuten\s*(?:vol\.)?\s*(.+)\)")
 
 
 def date_num_compare(magazine: str, issue: str) -> bool:
-	global licensed_magazines
-
 	if " " in issue:
 		issues = issue.split(" ")
 
@@ -21,27 +57,27 @@ def date_num_compare(magazine: str, issue: str) -> bool:
 			ans = date_num_compare(magazine, issues[1])
 			return ans
 
-	pattern = re.compile(r"(\d+)-(\d+)")
-	pattern2 = re.compile(r"\D*(\d+)\D*")
-
-	match = re.match(pattern, issue)
-	match2 = re.match(pattern2, issue)
+	match = DATE_PATTERN.match(issue)
+	match2 = DATE_PATTERN_2.match(issue)
 
 	if match is not None:
-		startdate = licensed_magazines[magazine][1]
-		enddate = licensed_magazines[magazine][2]
+		startdate = LICENSED_MAGAZINES["partially_licensed"][magazine][0]
+		enddate = LICENSED_MAGAZINES["partially_licensed"][magazine][1]
 
-		startmatch = re.match(pattern, startdate)
-		endmatch = re.match(pattern, enddate)
+		startmatch =  DATE_PATTERN.match(startdate)
+		endmatch = DATE_PATTERN.match(enddate)
 
 		issueyear = int(match.group(1))
 		issuemonth = int(match.group(2))
 
-		startyear = int(startmatch.group(1))
-		startmonth = int(startmatch.group(2))
+		if startmatch and endmatch:
+			startyear = int(startmatch.group(1))
+			startmonth = int(startmatch.group(2))
 
-		endyear = int(endmatch.group(1))
-		endmonth = int(endmatch.group(2))
+			endyear = int(endmatch.group(1))
+			endmonth = int(endmatch.group(2))
+		else:
+			raise AttributeError('Failed to find issue number!')
 
 		if startyear > issueyear or issueyear > endyear:
 			return False
@@ -49,10 +85,11 @@ def date_num_compare(magazine: str, issue: str) -> bool:
 			return False
 		elif endyear == issueyear and endmonth < issuemonth:
 			return False
+
 		return True
-	else:
-		startnum = licensed_magazines[magazine][3]
-		endnum = licensed_magazines[magazine][4]
+	elif match2 is not None:
+		startnum = LICENSED_MAGAZINES["partially_licensed"][magazine][2]
+		endnum = LICENSED_MAGAZINES["partially_licensed"][magazine][3]
 
 		if endnum == -1:
 			endnum = 100000000
@@ -60,26 +97,8 @@ def date_num_compare(magazine: str, issue: str) -> bool:
 		issuenum = int(match2.group(1))
 
 		return startnum <= issuenum <= endnum
-
-
-def always_licensed(magazine, issue):
-	return True
-
-
-licensed_magazines = {
-	"kairakuten": [date_num_compare, "2015-06", "9999-99", None, None],
-	"x-eros": [date_num_compare, None, None, 30, -1],
-	"shitsurakuten": [date_num_compare, "2016-04", "9999-99", None, None],
-	"kairakuten beast": [date_num_compare, "2016-12", "9999-99", None, None],
-	"bavel": [date_num_compare, "2017-06", "9999-99", None, None],
-	"europa": [date_num_compare, "2017-04", "9999-99", 11, -1],
-	"girls form": [date_num_compare, None, None, 13, 16],
-	"happining": [always_licensed],
-	"aoha": [always_licensed],
-	"weekly kairakuten": [always_licensed],
-	"dascomi": [always_licensed],
-	"koh": [date_num_compare, "2013-12", "2014-07", 1, 2]
-}
+	else:
+		return False
 
 
 # merge fetching everything lol
@@ -94,55 +113,58 @@ async def process_site(link: str) -> tuple[str, list[str] | None, str | None, li
 		language = list()
 
 		if 'nhentai' in link:
-			response = await session.get(link)
+			numbers_match = NUMBERS_REGEX.search(link)
+			numbers = int(numbers_match.group(1))
+
+			api_url = f"https://nhentai.net/api/gallery/{numbers}"
+
+			response = await session.get(api_url)
 			code = response.status
-			if code == 503 or code == 403:  # cloudflare IUAM
+
+			if code == 403 or code == 503 or 'application/json' not in response.headers.get('Content-Type', ''):  # cloudflare IUAM
 				return "Cloudflare IUAM", None, None, None, None, None, None
 
-			page = await response.text()
-			soup = BeautifulSoup(page, 'html.parser')
-			title = soup.find_all('h1', class_="title")[0].get_text()
+			data = await response.json()
 
-			tag_extractor = re.compile(r"/tag/(.*)/")
-			artist_extractor = re.compile(r"/artist/(.*)/")
-			parody_extractor = re.compile(r"/parody/(.*)/")
-			character_extractor = re.compile(r"/character/(.*)/")
-			page_extractor = re.compile(r"/search/\?q=pages.*")
-			language_extractor = re.compile(r"/language/(.*)/")
-			link_pile = soup.find_all('a', href=tag_extractor)
-			artist_pile = soup.find_all('a', href=artist_extractor)
-			parody_pile = soup.find_all('a', href=parody_extractor)
-			character_pile = soup.find_all('a', href=character_extractor)
-			language_pile = soup.find_all('a', href=language_extractor)
-			pages = int(soup.find('a', class_='tag', href=page_extractor).find('span', class_='name').string.strip())
+			title = data["titles"]["english"] if data["titles"]["english"] else data["titles"]["pretty"] if data["titles"]["pretty"] else "None"
 
-			for cur_link in link_pile:
-				link_text = cur_link.find('span', class_='name')
-				tags.append(link_text.text)
+			for tag in data["tags"]:
+				match tag["type"]:
+					case 'language':
+						if tag["name"] != 'translated' and tag["name"] != 'rewrite':
+							language.append(tag["name"])
+					case 'parody':
+						if tag["name"] != 'original':
+							parody_match = re.search(fr'(?i)({tag["name"]})', data["titles"]["english"])
 
-			for cur_link in artist_pile:
-				link_text = cur_link.find('span', class_='name')
-				temp = link_text.text.split(' ')
-				for i in range(len(temp)):
-					temp[i] = temp[i].capitalize()
-				artists.append(' '.join(temp))
+							if parody_match:
+								parodies.append(parody_match.group(1))
+							else:
+								parodies.append(tag["name"].title())
+					case 'character':
+						characters.append(tag["name"])
+					case 'tag':
+						tags.append(tag["name"])
+					case 'artist':
+						artist_match = re.search(fr'(?i)({tag["name"]})', data["titles"]["english"])
 
-			for cur_link in parody_pile:
-				link_text = cur_link.find('span', class_='name')
-				if link_text.text != 'original':
-					parodies.append(link_text.text)
+						if artist_match:
+							artists.append(artist_match.group(1))
+						else:
+							artists.append(tag["name"].title())
+					case _:
+						continue
 
-			for cur_link in character_pile:
-				link_text = cur_link.find('span', class_='name')
-				characters.append(link_text.text)
-
-			for cur_link in language_pile:
-				link_text = cur_link.find('span', class_='name')
-				language.append(link_text.text)
-
-		elif 'e-hentai' in link:
+			pages = data["num_pages"]
+		else:
 			try:
-				gallery_id, gallery_token = re.search(r'/g/(\d+?)/(.+?)/', link).group(1, 2)
+				match = re.search(r'/g/(\d+?)/(.+?)/', link)
+
+				if match is None:
+					raise AttributeError('Failed to find gallery ID and token')
+
+				gallery_id, gallery_token = match.group(1, 2)
+
 				response = await session.post('https://api.e-hentai.org/api.php',
 					json={
 						"method": "gdata",
@@ -151,38 +173,56 @@ async def process_site(link: str) -> tuple[str, list[str] | None, str | None, li
 						],
 						"namespace": 1
 					})
+
 				resp = await response.json(content_type='text/html')
+
 				if 'error' in resp['gmetadata'][0]:
 					raise RuntimeError(resp['error'])
+
 				data = resp['gmetadata'][0]
 
 				title = data['title'].strip()
-				tags = list((seq(data['tags'])
-						.filter(lambda s: re.match(r'(?:female|male|mixed|other):', s))))
-				artists = list((seq(data['tags'])
-							.filter(lambda s: re.match(r'artist', s))
-							.map(lambda s: re.match(r'artist:(.+)', s)[1])
-							.map(lambda s: ' '.join((w.capitalize() for w in s.split())))))
-				parodies = list((seq(data['tags'])
-							.filter(lambda s: re.match(r'parody', s))
-							.map(lambda s: re.match(r'parody:(.+)', s)[1])
-							.filter(lambda s: s != 'original')))
-				characters = list((seq(data['tags'])
-							.filter(lambda s: re.match(r'character', s))
-							.map(lambda s: re.match(r'character:(.+)', s)[1])))
+
+				for tag in data['tags']:
+					if ':' in tag:
+						namespace, name = tag.split(':')
+
+						match namespace:
+							case 'artist':
+								artist_match = re.search(fr'(?i)({name})', title)
+
+								if artist_match:
+									artists.append(artist_match.group(1))
+								else:
+									artists.append(name.title())
+							case 'parody':
+								if name != 'original':
+									parody_match = re.search(fr'(?i)({name})', data["title"])
+
+									if parody_match:
+										parodies.append(parody_match.group(1))
+									else:
+										parodies.append(name.title())
+							case "character":
+								characters.append(name)
+							case "language":
+								if name not in ["translated", "rewrite"]:
+									language.append(name)
+							case 'female' | "male" | "mixed" | "other":
+								tags.append(tag)
+							case _:
+								continue
+				
 				pages = int(data['filecount'])
-				language = list((seq(data['tags'])
-							.filter(lambda s: re.match(r'language', s))
-							.map(lambda s: re.match(r'language:(.+)', s)[1])))
-			except RuntimeError as e:
-				print('E-hentai error: ' + str(e))
+			except (AttributeError, RuntimeError) as e:
+				print(f'E-hentai error: {e}')
 				return 'E-Hentai error', None, None, None, None, None, None
 
 		print([title, tags, ', '.join(artists), parodies, characters, pages, language])
 		return title, tags, ', '.join(artists), parodies, characters, pages, language
 
 
-async def check_link(link):
+async def check_link(link: str) -> tuple[str | None, bool | None, str | list[list[str] | str | int | None]]:
 	title, tags, artists, parodies, characters, pages, lang = await process_site(link)
 
 	if title == "Cloudflare IUAM":
@@ -190,30 +230,24 @@ async def check_link(link):
 	elif title == 'E-hentai error':
 		return None, None, "E-hentai error"
 
-	pattern_extractor = re.compile(
-		r"^(?:\s*(?:=.*?=|<.*?>|\[.*?]|\(.*?\)|{.*?})\s*)*(?:[^[|\](){}<>=]*\s*\|\s*)?([^\[|\](){}<>=]*?)(?:\s*(?:=.*?=|<.*?>|\[.*?]|\(.*?\)|{.*?})\s*)*$")
-	match = pattern_extractor.match(title)
+	match = TITLE_EXTRACTOR.match(title)
 
 	parsed_title = title
+
 	if match:
 		parsed_title = match.group(1)
+
+	print([parsed_title, artists, tags, parodies, characters, pages, lang])
 
 	# Make the title lowercase
 	title = title.lower()
 
-	# See if this doujin has a magazine associated with it
-	# (girls forM is annoying because it doesn't have a COMIC, so I have to use another regex)
-	# (so is Weekly Kairakuten)
-	pattern1 = re.compile(r".*\(\s*comic\s*(.+?)\s*(?:vol\.)?\s*((\d|-|#|,|\s)*)\)")
-	pattern2 = re.compile(r".*\(\s*girls\s*form\s*(?:vol\.)?\s*(.+?)\)")
-	pattern3 = re.compile(r".*\(\s*weekly\s*kairakuten\s*(?:vol\.)?\s*(.+)\)")
-
 	magazine_name = None
 	magazine_issue = None
 
-	match1 = re.match(pattern1, title)
-	match2 = re.match(pattern2, title)
-	match3 = re.match(pattern3, title)
+	match1 = MAGAZINE_REGEX.match(title)
+	match2 = GIRLS_FORM_REGEX.match(title)
+	match3 = WEEKLY_MAG_REGEX.match(title)
 
 	# Extract the magazine issue and name
 	if match1 is not None:
@@ -235,25 +269,25 @@ async def check_link(link):
 	licensed = False
 
 	# If this is in a licensed magazine, check if it's in a licensed issue
-	if magazine_name in licensed_magazines:
-		try:
-			licensed = licensed_magazines[magazine_name][0](magazine_name, magazine_issue)
-		except Exception:
-			# Something has gone very wrong with a regular expression while trying to fetch the issue.
-			# In other words, the regular expression has failed. Ignore the post - the mods will remove it if it's
-			# actually licensed.
-			traceback.print_exc()
-			print("Error while detecting magazine. Setting licensed to false and continuing.")
+	if magazine_name and magazine_issue:
+		if magazine_name in LICENSED_MAGAZINES["always_licensed"]:
+			licensed = True
+		elif magazine_name in LICENSED_MAGAZINES["partially_licensed"]:
+			try:
+				licensed = date_num_compare(magazine_name, magazine_issue)
+			except Exception:
+				# Something has gone very wrong with a regular expression while trying to fetch the issue.
+				# In other words, the regular expression has failed. Ignore the post - the mods will remove it if it's
+				# actually licensed.
+				traceback.print_exc()
+				print("Error while detecting magazine. Setting licensed to false and continuing.")
 
-	market = "2d-market.com" in title
+		if licensed:
+			return magazine_name.upper() + " " + magazine_issue, market, [parsed_title, artists, tags, parodies, characters,
+																		pages, lang]
 
-	print([parsed_title, artists, tags, parodies, characters, pages, lang])
+	return None, market, [parsed_title, artists, tags, parodies, characters, pages, lang]
 
-	if licensed:
-		return magazine_name.upper() + " " + magazine_issue, market, [parsed_title, artists, tags, parodies, characters,
-		                                                              pages, lang]
-	else:
-		return None, market, [parsed_title, artists, tags, parodies, characters, pages, lang]
 
 # a, b, data = asyncio.run(check_link('https://nhentai.net/g/374491/'))
 # print(a, b, data)

--- a/hentai_fetcher.py
+++ b/hentai_fetcher.py
@@ -114,6 +114,10 @@ async def process_site(link: str) -> tuple[str, list[str] | None, str | None, li
 
 		if 'nhentai' in link:
 			numbers_match = NUMBERS_REGEX.search(link)
+
+			if numbers_match is None:
+					raise AttributeError('Failed to find nhentai numbers')
+
 			numbers = int(numbers_match.group(1))
 
 			api_url = f"https://nhentai.net/api/gallery/{numbers}"

--- a/hentai_fetcher.py
+++ b/hentai_fetcher.py
@@ -116,7 +116,7 @@ async def process_site(link: str) -> tuple[str, list[str] | None, str | None, li
 			numbers_match = NUMBERS_REGEX.search(link)
 
 			if numbers_match is None:
-					raise AttributeError('Failed to find nhentai numbers')
+				raise AttributeError('Failed to find nhentai numbers')
 
 			numbers = int(numbers_match.group(1))
 

--- a/hentai_fetcher.py
+++ b/hentai_fetcher.py
@@ -244,6 +244,7 @@ async def check_link(link: str) -> tuple[str | None, bool | None, str | list[lis
 
 	magazine_name = None
 	magazine_issue = None
+	market = "2d-market.com" in title
 
 	match1 = MAGAZINE_REGEX.match(title)
 	match2 = GIRLS_FORM_REGEX.match(title)

--- a/main.py
+++ b/main.py
@@ -1,12 +1,11 @@
+import asyncio
 import json
 import time
-import asyncio
 import traceback
 
 import praw
-from prawcore import ResponseException
 from http.client import HTTPException
-from prawcore import RequestException
+from prawcore import RequestException, ResponseException
 
 import process_comment
 import process_post
@@ -25,7 +24,7 @@ async def main():
 	                     username=config['username'],
 	                     password=config['password'],
 	                     check_for_async=False)
-	print('Logged in as u/' + str(reddit.user.me()))
+	print(f'Logged in as u/{reddit.user.me()}')
 
 	subreddit = reddit.subreddit(config['subreddit'])
 

--- a/process_comment.py
+++ b/process_comment.py
@@ -407,7 +407,7 @@ def update_wiki(reddit: Reddit):
 	)
 	id_extractor = re.compile(r'/comments/([^/]*)/')
 	for post in all_posts:
-		wiki_text += f'| {post[1] if len(post[1]) < 30 else ("[" + post[1][:30] + "...](" + post[1] + ")")} | {datetime.datetime.utcfromtimestamp(post[2]).strftime("%b %d, %Y %I:%M %p")} | https://redd.it/{id_extractor.search(post[0]).group(1)} |\n'
+		wiki_text += f'| {post[1] if len(post[1]) < 30 else ("[" + post[1][:30] + "...](" + post[1] + ")")} | {datetime.datetime.fromtimestamp(post[2], tz=datetime.UTC).strftime("%b %d, %Y %I:%M %p")} | https://redd.it/{id_extractor.search(post[0]).group(1)} |\n'
 
 	repostspage = subreddit_wiki['posts']
 	repostspage.edit(content=wiki_text)

--- a/process_comment.py
+++ b/process_comment.py
@@ -507,12 +507,12 @@ def format_site_tags(tags_list: list[str]) -> str:
 		}
 
 		for tag in tags_list:
-			namespace, name = tag.split(':')
+			namespace, name = tag.lower().split(':')
 
-			if namespace.lower() in sorted_tags:
+			if namespace in sorted_tags:
 				if 'threesome' in name:
 					name = name[:3].upper() + name[3:]
-				elif name.lower() in ['bbw', 'bbm', 'milf', 'dilf']:
+				elif name in ['bbw', 'bbm', 'milf', 'dilf']:
 					name = name.upper()
 
 					sorted_tags[namespace].append(name)

--- a/process_comment.py
+++ b/process_comment.py
@@ -596,6 +596,12 @@ async def format_body(url: str, data: tuple | None = None) -> str:
 		nums_match = nums_regex.match(url)
 		nums = nums_match.group(1)
 
+		if '/' in nums:
+			nums_pages = nums.split('/')
+			cubari_link = f"https://cubari.moe/read/nhentai/{nums_pages[0]}/1/{nums_pages[1]}/"
+		else:
+			cubari_link = f"https://cubari.moe/read/nhentai/{nums}/1/1/"
+
 		if data:
 			parodies = '' if not data[3] else f"**Parodies:**  \n{(', '.join(data[3])).title()}\n\n"
 			characters = '' if not data[4] else f"**Characters:**  \n{', '.join(i.capitalize() for i in data[4])}\n\n"
@@ -611,7 +617,7 @@ async def format_body(url: str, data: tuple | None = None) -> str:
 				god_list = ""
 
 			body = (
-				f"The source OP provided:  \n> <{url}>\n\n"
+				f"The source OP provided:  \n> <{url}>\n\nAlt link: [cubari.moe]({cubari_link})\n\n"
 				f'**{markdown_escape(data[0])}**  \nby {data[1] if data[1] else entry.get("author", "Unknown")}\n\n'
 				f'{data[5]} pages\n\n{parodies}{characters}{tags}{god_list}'
 				f'{config["suffix"]}')
@@ -634,7 +640,7 @@ async def format_body(url: str, data: tuple | None = None) -> str:
 				god_list = ""
 
 			body = (
-				f"The source OP provided:  \n> <{url}>" + (
+				f"The source OP provided:  \n> <{url}>" + f"\n\nAlt link: [cubari.moe]({cubari_link})" + (
 				f"\n\n**{markdown_escape(entry['title'])}**  \nby {entry['author']} "
 				f"{pages}{parody}{characters}{tags}" if has_entry else "") + "\n\n" + god_list +
 				"\\-\\-\\-\n\nNote: nhentai information fetching is broken, due to them enabling Cloudflare "

--- a/process_comment.py
+++ b/process_comment.py
@@ -754,12 +754,9 @@ def check_data(magazine: str | None, market: bool, data: list) -> tuple:
 
 	# If we are dealing with E-Hentai tags, remove the namespaces
 	if data[2] and ":" in data[2][0]:
-		data[2] = set([tag.split(":")[1] for tag in data[2]])
+		tags_without_namespaces = set([tag.split(":")[1] for tag in data[2]])
 
-	detected_tags = []
-	for tag in data[2]:
-		if tag in unwholesome_tags:
-			detected_tags.append(tag.title())
+	detected_tags = [tag.title() for tag in tags_without_namespaces if tag in unwholesome_tags]
 
 	if detected_tags:
 		# Oh no, there's an illegal tag!

--- a/process_comment.py
+++ b/process_comment.py
@@ -1,18 +1,19 @@
-import re
-import json
-import sqlite3
 import asyncio
-import time
-import zlib
 import base64
 import datetime
+import json
+import re
+import sqlite3
+import time
+import zlib
 
-from sqlite3 import Error, Connection
-from praw.models import Comment
 from praw import Reddit
+from praw.models import Comment
+from sqlite3 import Connection, Error
 
 import hentai_fetcher
 import wholesomelist_fetcher
+
 
 removals = json.load(open('removals.json'))
 

--- a/process_comment.py
+++ b/process_comment.py
@@ -592,7 +592,7 @@ async def format_body(url: str, data: tuple | None = None) -> str:
 				f'{config["suffix"]}')
 
 	elif 'nhentai' in url:
-		nums_regex = re.compile(r"https://nhentai\.net/g/([0-9/]+)/")
+		nums_regex = re.compile(r"https://(?:www\.)?nhentai\.net/g/([0-9/]+)/")
 		nums_match = nums_regex.match(url)
 		nums = nums_match.group(1)
 
@@ -649,7 +649,8 @@ async def format_body(url: str, data: tuple | None = None) -> str:
 				f'{config["suffix"]}')
 
 	else:
-		imgchest_match = re.search(r'([0-9a-zA-Z]{11})', url)
+		imgchest_regex = re.compile(r'https?://(?:www\.)?imgchest\.com\/p\/([0-9a-zA-Z]{11})')
+		imgchest_match = imgchest_regex.match(url)
 
 		if imgchest_match:
 			cubari_link = f'https://cubari.moe/read/imgchest/{imgchest_match.group(1)}/1/1/'

--- a/process_comment.py
+++ b/process_comment.py
@@ -452,7 +452,7 @@ def extract_url(body: str) -> str | None:
 	if "imgur.io" in url:
 		url = url.replace(".io", ".com")
 
-	if not url[-1] == "/":
+	if url[-1] != "/":
 		url = url + "/"
 
 	return url

--- a/process_comment.py
+++ b/process_comment.py
@@ -596,12 +596,6 @@ async def format_body(url: str, data: tuple | None = None) -> str:
 		nums_match = nums_regex.match(url)
 		nums = nums_match.group(1)
 
-		if '/' in nums:
-			nums_pages = nums.split('/')
-			cubari_link = f"https://cubari.moe/read/nhentai/{nums_pages[0]}/1/{nums_pages[1]}/"
-		else:
-			cubari_link = f"https://cubari.moe/read/nhentai/{nums}/1/1/"
-
 		if data:
 			parodies = '' if not data[3] else f"**Parodies:**  \n{(', '.join(data[3])).title()}\n\n"
 			characters = '' if not data[4] else f"**Characters:**  \n{', '.join(i.capitalize() for i in data[4])}\n\n"
@@ -617,7 +611,7 @@ async def format_body(url: str, data: tuple | None = None) -> str:
 				god_list = ""
 
 			body = (
-				f"The source OP provided:  \n> <{url}>\n\nAlt link: [cubari.moe]({cubari_link})\n\n"
+				f"The source OP provided:  \n> <{url}>\n\n"
 				f'**{markdown_escape(data[0])}**  \nby {data[1] if data[1] else entry.get("author", "Unknown")}\n\n'
 				f'{data[5]} pages\n\n{parodies}{characters}{tags}{god_list}'
 				f'{config["suffix"]}')
@@ -640,7 +634,7 @@ async def format_body(url: str, data: tuple | None = None) -> str:
 				god_list = ""
 
 			body = (
-				f"The source OP provided:  \n> <{url}>" + f"\n\nAlt link: [cubari.moe]({cubari_link})" + (
+				f"The source OP provided:  \n> <{url}>" + (
 				f"\n\n**{markdown_escape(entry['title'])}**  \nby {entry['author']} "
 				f"{pages}{parody}{characters}{tags}" if has_entry else "") + "\n\n" + god_list +
 				"\\-\\-\\-\n\nNote: nhentai information fetching is broken, due to them enabling Cloudflare "

--- a/process_comment.py
+++ b/process_comment.py
@@ -489,40 +489,32 @@ def get_god_list_str(entry: dict, url: str) -> str:
 	return god_list_str
 
 
-def format_site_tags(tags_list: list) -> str:
-	sorted_tags = {
-		"male": [],
-		"female": [],
-		"mixed": [],
-		"other": []
-	}
-
-	eh_regex = re.compile("^(female|male|mixed|other):.*$")
-	eh_tags = list(filter(eh_regex.match, tags_list))
+def format_site_tags(tags_list: list[str]) -> str:
+	tags_list.sort()
 
 	# Not E-Hentai tags, so just join them
-	if not eh_tags:
+	if not any(':' in t for t in tags_list):
 		str_tags = ', '.join(tags_list)
 		return str_tags
 
 	else:
-		for tag in eh_tags:
-			x = re.match(eh_regex, tag)
-			if x is None:
-				continue
-			tag_namespace = x.group(1)
-			tag = re.sub(r'^.*:', '', tag)
+		sorted_tags = {
+			"male": [],
+			"female": [],
+			"mixed": [],
+			"other": []
+		}
 
-			if 'threesome' in tag:
-				tag = tag[:3].upper() + tag[3:]
-			elif re.match(r'bbw|bbm|milf|dilf', tag):
-				tag = tag.upper()
+		for tag in tags_list:
+			namespace, name = tag.split(':')
 
-			match tag_namespace:
-				case 'female' | "male" | "mixed" | "other":
-					sorted_tags[tag_namespace].append(tag)
-				case _:
-					continue
+			if namespace.lower() in sorted_tags:
+				if 'threesome' in name:
+					name = name[:3].upper() + name[3:]
+				elif name.lower() in ['bbw', 'bbm', 'milf', 'dilf']:
+					name = name.upper()
+
+					sorted_tags[namespace].append(name)
 
 		str_tags = []
 

--- a/process_post.py
+++ b/process_post.py
@@ -31,7 +31,7 @@ async def process_post(submission: Submission):
 	# Do not respond to memes!
 	# Or non-image posts.
 	# god I miss nullish coalescing
-	if (hasattr(submission, 'link_flair_text') and submission.link_flair_text and ('meme' in submission.link_flair_text.lower() or 'news' in submission.link_flair_text.lower())) or submission.is_self:
+	if (getattr(submission, 'link_flair_text', False) and any(f in submission.link_flair_text.lower() for f in ['meme', 'news'])) or submission.is_self:
 		print("Either this is flaired Meme or this is a self-post.")
 		return
 

--- a/process_post.py
+++ b/process_post.py
@@ -24,6 +24,8 @@ c = conn.cursor()
 
 config = json.load(open('config.json'))
 
+AUTHOR_MATCHER = re.compile(r'.*\[.*].*')
+
 
 async def process_post(submission: Submission):
 	print("New post: " + submission.title)
@@ -42,8 +44,8 @@ async def process_post(submission: Submission):
 		return
 
 	# Make sure they have an author in the post.
-	author_matcher = re.compile(r'.*\[.*].*')
-	if not author_matcher.match(submission.title):
+
+	if not AUTHOR_MATCHER.match(submission.title):
 		comment = submission.reply("**Post titles must have the author in square brackets.**\n\n To avoid getting your post removed, make sure the author is in the "
 		                 "title (i.e. [Author] Title).\n\n" + config['suffix'])
 

--- a/process_removal.py
+++ b/process_removal.py
@@ -1,7 +1,7 @@
+import sqlite3
 from praw import Reddit
 from praw.models import Submission
-import sqlite3
-from sqlite3 import Error, Connection
+from sqlite3 import Connection, Error
 
 import process_comment
 
@@ -32,4 +32,5 @@ def process_removal(removal_action, reddit: Reddit):
 	print('Removal detected. Updating database...')
 	c.execute('UPDATE posts SET removed=1 WHERE url=?', (removal_action.target_permalink,))
 	conn.commit()
+
 	process_comment.update_wiki(reddit)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ praw>=7.2.0
 aiohttp>=3.7.4
 beautifulsoup4>=4.9.3
 prawcore>=2.0.0
-pyfunctional>=1.4.3

--- a/update_common_reposts.py
+++ b/update_common_reposts.py
@@ -1,12 +1,13 @@
-import time
 import datetime
-import praw
 import json
+import praw
 import re
 import sqlite3
-from sqlite3 import Error, Connection
+import time
+from sqlite3 import Connection, Error
 
 from process_comment import decode_blob, encode_blob
+
 
 config = json.load(open('config.json'))
 

--- a/update_common_reposts.py
+++ b/update_common_reposts.py
@@ -10,7 +10,7 @@ from process_comment import decode_blob, encode_blob
 
 config = json.load(open('config.json'))
 
-print(datetime.datetime.utcfromtimestamp(int(time.time())).strftime("%b %d, %Y %I:%M %p"))
+print(datetime.datetime.fromtimestamp(int(time.time()), tz=datetime.UTC).strftime("%b %d, %Y %I:%M %p"))
 print(str(b'test', 'utf-8'))
 
 

--- a/wholesomelist_fetcher.py
+++ b/wholesomelist_fetcher.py
@@ -1,10 +1,11 @@
 import aiohttp
-import json
 import asyncio
+import json
 
 
 async def process_nums(nums: int|str) -> tuple[bool, dict]:
-	link = "https://wholesomelist.com/api/check?code=" + str(nums)
+	link = f"https://wholesomelist.com/api/check?code={nums}"
+
 	async with aiohttp.ClientSession() as session:
 		resp = await session.get(link)
 		data = await resp.text()
@@ -26,6 +27,7 @@ async def process_nums(nums: int|str) -> tuple[bool, dict]:
 			return True, entry
 		else:
 			return False, {}
+
 
 # result, test = asyncio.run(process_nums(258133))
 # print("tags" in test)

--- a/wholesomelist_fetcher.py
+++ b/wholesomelist_fetcher.py
@@ -16,7 +16,7 @@ async def process_nums(nums: int|str) -> tuple[bool, dict]:
 
 		print(payload)
 
-		if payload['result']:
+		if payload.get('result'):
 			entry = payload['entry']
 
 			for key, value in entry.items():


### PR DESCRIPTION
* Refactor hentai_fetcher, ditching pyfunctional and adding extra checks
* Move regexes to global scope to avoid compiling them per function call
* Use nhentai API to simplify fetching
* Return namespaces for E-Hentai fetching, so they can be included in the comment
* Fix Imgchest regex, previous one was way too broad
* Remove E-Hentai tag namespaces when checking for unwholesome tags
* Simplify sitetags formatter
* Replace deprecated datetime.utcfromtimestamp function
* Add some folders to .gitignore
* Minor fixes and formatting